### PR TITLE
[WIP] Remove MRPT dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,22 +11,14 @@ find_package(catkin REQUIRED COMPONENTS
   nav_msgs
   sensor_msgs
   std_msgs
-  tf  
+  tf
+  cmake_modules
 )
-
-set(MRPT_DONT_USE_DBG_LIBS 1)
 
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS system)
-find_package(cmake_modules REQUIRED)
+
 find_package(Eigen3 REQUIRED)
-find_package(MRPT REQUIRED base obs) # maps slam
-#include_directories(${MRPT_INCLUDE_DIRS})
-MESSAGE( STATUS "MRPT_INCLUDE_DIRS: " ${MRPT_INCLUDE_DIRS})
-#link_directories(${MRPT_LIBRARY_DIRS})
-MESSAGE( STATUS "MRPT_LIBRARY_DIRS: " ${MRPT_LIBRARIES})
-
-
 
 ###################################
 ## catkin specific configuration ##
@@ -38,10 +30,10 @@ MESSAGE( STATUS "MRPT_LIBRARY_DIRS: " ${MRPT_LIBRARIES})
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
- INCLUDE_DIRS include
+ INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
  LIBRARIES ${PROJECT_NAME}
  CATKIN_DEPENDS nav_msgs roscpp sensor_msgs std_msgs tf
- DEPENDS MRPT
+ DEPENDS #Eigen3
 )
 
 ## Specify additional locations of header files
@@ -52,15 +44,12 @@ include_directories(
   SYSTEM
   ${catkin_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
-  ${EIGEN_INCLUDE_DIRS}
-  ${MRPT_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 ## Declare a cpp library
-add_library(${PROJECT_NAME}
-    src/CLaserOdometry2D.cpp
-)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${MRPT_LIBS})
+add_library(${PROJECT_NAME} src/CLaserOdometry2D.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 ## Declare a cpp executable
 add_executable(rf2o_laser_odometry_node src/CLaserOdometry2DNode.cpp)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,3 @@ RF2O is a fast and precise method to estimate the planar motion of a lidar from 
 Its very low computational cost (0.9 milliseconds on a single CPU core) together whit its high precission, makes RF2O a suitable method for those robotic applications that require planar odometry.
 
 For full description of the algorithm, please refer to: **Planar Odometry from a Radial Laser Scanner. A Range Flow-based Approach. ICRA 2016** Available at: http://mapir.isa.uma.es/work/rf2o
-
-
-# Requirements
-RF2O core is implemented within the **Mobile Robot Programming Toolkit** [MRPT](http://www.mrpt.org/), so it is necessary to install this powerful library (see instructions [here](http://www.mrpt.org/download-mrpt/))
-So far RF2O has been tested with the Ubuntu official repository version (MRPT v1.3), and we are working to update it to MRPT v.1.9

--- a/include/rf2o_laser_odometry/CLaserOdometry2D.h
+++ b/include/rf2o_laser_odometry/CLaserOdometry2D.h
@@ -16,40 +16,20 @@
 #ifndef CLaserOdometry2D_H
 #define CLaserOdometry2D_H
 
+// std header
+#include <iostream>
+#include <fstream>
+#include <numeric>
+
+// ROS headers
 #include <ros/ros.h>
 #include <nav_msgs/Odometry.h>
 #include <sensor_msgs/LaserScan.h>
 
-// MRPT related headers
-#include <mrpt/version.h>
-#if MRPT_VERSION>=0x130
-#   include <mrpt/obs/CObservation2DRangeScan.h>
-#   include <mrpt/obs/CObservationOdometry.h>
-    typedef mrpt::obs::CObservation2DRangeScan CObservation2DRangeScan;
-#else
-#   include <mrpt/slam/CObservation2DRangeScan.h>
-#   include <mrpt/slam/CObservationOdometry.h>
-    typedef mrpt::poses::CObservation2DRangeScan CObservation2DRangeScan;
-
-#endif
-
-#if MRPT_VERSION<0x150
-#   include <mrpt/system/threads.h>
-#endif
-
-#include <mrpt/system/os.h>
-#include <mrpt/poses/CPose3D.h>
-#include <mrpt/utils.h>
-//#include <mrpt/opengl.h>
-#include <mrpt/math/CHistogram.h>
-
-#include <boost/bind.hpp>
+// Eigen headers
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 #include <unsupported/Eigen/MatrixFunctions>
-#include <iostream>
-#include <fstream>
-#include <numeric>
 
 namespace rf2o {
 template <typename T>
@@ -113,7 +93,7 @@ public:
 
 protected:
 
-  bool verbose,module_initialized,first_laser_scan;
+  bool verbose, module_initialized, first_laser_scan;
 
     // Internal Data
 	std::vector<Eigen::MatrixXf> range;
@@ -144,8 +124,6 @@ protected:
   MatrixS31 Var;	//3 unknowns: vx, vy, w
   IncrementCov cov_odo;
 
-
-
     //std::string LaserVarName;				//Name of the topic containing the scan lasers \laser_scan
 	float fps;								//In Hz
 	float fovh;								//Horizontal FOV
@@ -160,7 +138,7 @@ protected:
 
   double lin_speed, ang_speed;
 
-  ros::Duration	m_runtime;
+  ros::WallDuration	m_runtime;
     ros::Time last_odom_time, current_scan_time;
 
   MatrixS31 kai_abs_;
@@ -193,7 +171,7 @@ protected:
     void solveSystemNonLinear();
 	void filterLevelSolution();
 	void PoseUpdate();
-    void Reset(const Pose3d& ini_pose, CObservation2DRangeScan scan);
+    void Reset(const Pose3d& ini_pose/*, CObservation2DRangeScan scan*/);
 };
 
-#endif
+#endif // CLaserOdometry2D_H

--- a/include/rf2o_laser_odometry/CLaserOdometry2D.h
+++ b/include/rf2o_laser_odometry/CLaserOdometry2D.h
@@ -34,6 +34,7 @@
 #include <unsupported/Eigen/MatrixFunctions>
 
 namespace rf2o {
+
 template <typename T>
 inline int sign(T x) { return x<0 ? -1:1; }
 
@@ -61,7 +62,6 @@ inline Eigen::Matrix<T, 3, 3> matrixYaw(const T yaw)
 {
   return matrixRollPitchYaw<T>(0, 0, yaw);
 }
-} // namespace rf2o
 
 class CLaserOdometry2D
 {
@@ -174,5 +174,7 @@ protected:
   void PoseUpdate();
   void Reset(const Pose3d& ini_pose/*, CObservation2DRangeScan scan*/);
 };
+
+} /* namespace rf2o */
 
 #endif // CLaserOdometry2D_H

--- a/include/rf2o_laser_odometry/CLaserOdometry2D.h
+++ b/include/rf2o_laser_odometry/CLaserOdometry2D.h
@@ -36,7 +36,7 @@
 namespace rf2o {
 
 template <typename T>
-inline int sign(T x) { return x<0 ? -1:1; }
+inline T sign(const T x) { return x<T(0) ? -1:1; }
 
 template <typename Derived>
 inline typename Eigen::MatrixBase<Derived>::Scalar
@@ -170,7 +170,7 @@ protected:
   void findNullPoints();
   void solveSystemOneLevel();
   void solveSystemNonLinear();
-  void filterLevelSolution();
+  bool filterLevelSolution();
   void PoseUpdate();
   void Reset(const Pose3d& ini_pose/*, CObservation2DRangeScan scan*/);
 };

--- a/include/rf2o_laser_odometry/CLaserOdometry2D.h
+++ b/include/rf2o_laser_odometry/CLaserOdometry2D.h
@@ -160,9 +160,7 @@ protected:
 
   double lin_speed, ang_speed;
 
-    //mrpt::gui::CDisplayWindowPlots window;
-	mrpt::utils::CTicTac		m_clock;
-	float		m_runtime;
+  ros::Duration	m_runtime;
     ros::Time last_odom_time, current_scan_time;
 
   MatrixS31 kai_abs_;

--- a/include/rf2o_laser_odometry/CLaserOdometry2D.h
+++ b/include/rf2o_laser_odometry/CLaserOdometry2D.h
@@ -11,6 +11,8 @@
 *
 * Maintainer: Javier G. Monroy
 * MAPIR group: http://mapir.isa.uma.es/
+*
+* Modifications: Jeremie Deray
 ******************************************************************************************** */
 
 #ifndef CLaserOdometry2D_H
@@ -72,74 +74,74 @@ public:
   using MatrixS31 = Eigen::Matrix<Scalar, 3, 1>;
   using IncrementCov = Eigen::Matrix<Scalar, 3, 3>;
 
-	CLaserOdometry2D();
-    virtual ~CLaserOdometry2D() = default;
+  CLaserOdometry2D();
+  virtual ~CLaserOdometry2D() = default;
 
-    void init(const sensor_msgs::LaserScan& scan,
-              const geometry_msgs::Pose& initial_robot_pose);
+  void init(const sensor_msgs::LaserScan& scan,
+            const geometry_msgs::Pose& initial_robot_pose);
 
-    bool is_initialized();
+  bool is_initialized();
 
-    bool odometryCalculation(const sensor_msgs::LaserScan& scan);
+  bool odometryCalculation(const sensor_msgs::LaserScan& scan);
 
-    void setLaserPose(const Pose3d& laser_pose);
+  void setLaserPose(const Pose3d& laser_pose);
 
-    const Pose3d& getIncrement() const;
+  const Pose3d& getIncrement() const;
 
-    const IncrementCov& getIncrementCovariance() const;
+  const IncrementCov& getIncrementCovariance() const;
 
-    Pose3d& getPose();
-    const Pose3d& getPose() const;
+  Pose3d& getPose();
+  const Pose3d& getPose() const;
 
 protected:
 
   bool verbose, module_initialized, first_laser_scan;
 
-    // Internal Data
-	std::vector<Eigen::MatrixXf> range;
-	std::vector<Eigen::MatrixXf> range_old;
-	std::vector<Eigen::MatrixXf> range_inter;
-	std::vector<Eigen::MatrixXf> range_warped;
-	std::vector<Eigen::MatrixXf> xx;
-	std::vector<Eigen::MatrixXf> xx_inter;
-	std::vector<Eigen::MatrixXf> xx_old;
-	std::vector<Eigen::MatrixXf> xx_warped;
-	std::vector<Eigen::MatrixXf> yy;
-	std::vector<Eigen::MatrixXf> yy_inter;
-	std::vector<Eigen::MatrixXf> yy_old;
-	std::vector<Eigen::MatrixXf> yy_warped;
-	std::vector<Eigen::MatrixXf> transformations;
+  // Internal Data
+  std::vector<Eigen::MatrixXf> range;
+  std::vector<Eigen::MatrixXf> range_old;
+  std::vector<Eigen::MatrixXf> range_inter;
+  std::vector<Eigen::MatrixXf> range_warped;
+  std::vector<Eigen::MatrixXf> xx;
+  std::vector<Eigen::MatrixXf> xx_inter;
+  std::vector<Eigen::MatrixXf> xx_old;
+  std::vector<Eigen::MatrixXf> xx_warped;
+  std::vector<Eigen::MatrixXf> yy;
+  std::vector<Eigen::MatrixXf> yy_inter;
+  std::vector<Eigen::MatrixXf> yy_old;
+  std::vector<Eigen::MatrixXf> yy_warped;
+  std::vector<Eigen::MatrixXf> transformations;
 
-	Eigen::MatrixXf range_wf;
-	Eigen::MatrixXf dtita;
-	Eigen::MatrixXf dt;
-	Eigen::MatrixXf rtita;
-	Eigen::MatrixXf normx, normy, norm_ang;
-	Eigen::MatrixXf weights;
-	Eigen::MatrixXi null;
+  Eigen::MatrixXf range_wf;
+  Eigen::MatrixXf dtita;
+  Eigen::MatrixXf dt;
+  Eigen::MatrixXf rtita;
+  Eigen::MatrixXf normx, normy, norm_ang;
+  Eigen::MatrixXf weights;
+  Eigen::MatrixXi null;
 
-    Eigen::MatrixXf A,Aw;
-    Eigen::MatrixXf B,Bw;
+  Eigen::MatrixXf A,Aw;
+  Eigen::MatrixXf B,Bw;
 
   MatrixS31 Var;	//3 unknowns: vx, vy, w
   IncrementCov cov_odo;
 
-    //std::string LaserVarName;				//Name of the topic containing the scan lasers \laser_scan
-	float fps;								//In Hz
-	float fovh;								//Horizontal FOV
-	unsigned int cols;
-	unsigned int cols_i;
-	unsigned int width;
-	unsigned int ctf_levels;
-	unsigned int image_level, level;
-	unsigned int num_valid_range;
-    unsigned int iter_irls;
-	float g_mask[5];
+  //std::string LaserVarName;				//Name of the topic containing the scan lasers \laser_scan
+  float fps;								//In Hz
+  float fovh;								//Horizontal FOV
+  unsigned int cols;
+  unsigned int cols_i;
+  unsigned int width;
+  unsigned int ctf_levels;
+  unsigned int image_level, level;
+  unsigned int num_valid_range;
+  unsigned int iter_irls;
+  float g_mask[5];
 
   double lin_speed, ang_speed;
 
   ros::WallDuration	m_runtime;
-    ros::Time last_odom_time, current_scan_time;
+  ros::Time last_odom_time, current_scan_time;
 
   MatrixS31 kai_abs_;
   MatrixS31 kai_loc_;
@@ -154,24 +156,23 @@ protected:
   Pose3d robot_pose_;
   Pose3d robot_oldpose_;
 
-	bool test;
-    std::vector<double> last_m_lin_speeds;
-    std::vector<double> last_m_ang_speeds;
+  bool test;
+  std::vector<double> last_m_lin_speeds;
+  std::vector<double> last_m_ang_speeds;
 
-
-	// Methods
-	void createImagePyramid();
-	void calculateCoord();
-	void performWarping();
-	void calculaterangeDerivativesSurface();
-	void computeNormals();
-	void computeWeights();
-	void findNullPoints();
-	void solveSystemOneLevel();
-    void solveSystemNonLinear();
-	void filterLevelSolution();
-	void PoseUpdate();
-    void Reset(const Pose3d& ini_pose/*, CObservation2DRangeScan scan*/);
+  // Methods
+  void createImagePyramid();
+  void calculateCoord();
+  void performWarping();
+  void calculaterangeDerivativesSurface();
+  void computeNormals();
+  void computeWeights();
+  void findNullPoints();
+  void solveSystemOneLevel();
+  void solveSystemNonLinear();
+  void filterLevelSolution();
+  void PoseUpdate();
+  void Reset(const Pose3d& ini_pose/*, CObservation2DRangeScan scan*/);
 };
 
 #endif // CLaserOdometry2D_H

--- a/include/rf2o_laser_odometry/CLaserOdometry2D.h
+++ b/include/rf2o_laser_odometry/CLaserOdometry2D.h
@@ -89,7 +89,7 @@ public:
 
   using Pose2d = Eigen::Isometry2d;
   using Pose3d = Eigen::Isometry3d;
-  using MatrixF31 = Eigen::Matrix<Scalar, 3, 1>;
+  using MatrixS31 = Eigen::Matrix<Scalar, 3, 1>;
   using IncrementCov = Eigen::Matrix<Scalar, 3, 3>;
 
 	CLaserOdometry2D();
@@ -140,8 +140,9 @@ protected:
 
     Eigen::MatrixXf A,Aw;
     Eigen::MatrixXf B,Bw;
-	Eigen::Matrix<float, 3, 1> Var;	//3 unknowns: vx, vy, w
-	Eigen::Matrix<float, 3, 3> cov_odo;
+
+  MatrixS31 Var;	//3 unknowns: vx, vy, w
+  IncrementCov cov_odo;
 
 
 
@@ -164,10 +165,10 @@ protected:
 	float		m_runtime;
     ros::Time last_odom_time, current_scan_time;
 
-	mrpt::math::CMatrixFloat31 kai_abs;
-	mrpt::math::CMatrixFloat31 kai_loc;
-	mrpt::math::CMatrixFloat31 kai_loc_old;
-	mrpt::math::CMatrixFloat31 kai_loc_level;
+  MatrixS31 kai_abs_;
+  MatrixS31 kai_loc_;
+  MatrixS31 kai_loc_old_;
+  MatrixS31 kai_loc_level_;
 
   Pose3d last_increment_;
   Pose3d laser_pose_on_robot_;

--- a/package.xml
+++ b/package.xml
@@ -24,15 +24,14 @@
   <build_depend>tf</build_depend>
   <build_depend>cmake_modules</build_depend>   <!-- A common repository for CMake Modules which are not distributed with CMake but are commonly used by ROS packages. -->
                                                <!-- https://github.com/ros/cmake_modules/blob/0.3-devel/README.md -->
-  <build_depend>mrpt</build_depend>            <!-- Depend on mrpt system pkgs: http://www.mrpt.org/ -->
-
+  <build_depend>eigen</build_depend>
 
   <run_depend>nav_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>cmake_modules</run_depend>       <!-- For aditional dependencies such as Eigen -->
-  <run_depend>mrpt</run_depend>                <!-- Depend on mrpt system pkgs -->
+  <run_depend>cmake_modules</run_depend>   <!-- For aditional dependencies such as Eigen -->
+  <run_depend>eigen</run_depend>
 
 </package>

--- a/src/CLaserOdometry2D.cpp
+++ b/src/CLaserOdometry2D.cpp
@@ -17,6 +17,8 @@
 
 #include "rf2o_laser_odometry/CLaserOdometry2D.h"
 
+namespace rf2o {
+
 // --------------------------------------------
 // CLaserOdometry2D
 //---------------------------------------------
@@ -951,3 +953,5 @@ void CLaserOdometry2D::PoseUpdate()
     ang_speed = sum2 / last_m_ang_speeds.size();
     */
 }
+
+} /* namespace rf2o */

--- a/src/CLaserOdometry2D.cpp
+++ b/src/CLaserOdometry2D.cpp
@@ -175,7 +175,8 @@ bool CLaserOdometry2D::odometryCalculation(const sensor_msgs::LaserScan& scan)
     for (unsigned int i = 0; i<width; i++)
         range_wf(i) = scan.ranges[i];
 
-    m_clock.Tic();
+    ros::Time start = ros::Time::now();
+
     createImagePyramid();
 
     //Coarse-to-fine scheme
@@ -225,9 +226,9 @@ bool CLaserOdometry2D::odometryCalculation(const sensor_msgs::LaserScan& scan)
         filterLevelSolution();
     }
 
-    m_runtime = 1000*m_clock.Tac();
+    m_runtime = ros::Time::now() - start;
 
-    ROS_INFO_COND(verbose, "[rf2o] execution time (ms): %f", m_runtime);
+    ROS_INFO_COND(verbose, "[rf2o] execution time (ms): %f", (1000*m_runtime.toNSec()));
 
     //Update poses
     PoseUpdate();

--- a/src/CLaserOdometry2D.cpp
+++ b/src/CLaserOdometry2D.cpp
@@ -11,6 +11,8 @@
 *
 * Maintainer: Javier G. Monroy
 * MAPIR group: http://mapir.isa.uma.es/
+*
+* Modifications: Jeremie Deray
 ******************************************************************************************** */
 
 #include "rf2o_laser_odometry/CLaserOdometry2D.h"
@@ -36,109 +38,109 @@ void CLaserOdometry2D::setLaserPose(const Pose3d& laser_pose)
 
 bool CLaserOdometry2D::is_initialized()
 {
-    return module_initialized;
+  return module_initialized;
 }
 
 void CLaserOdometry2D::init(const sensor_msgs::LaserScan& scan,
                             const geometry_msgs::Pose& initial_robot_pose)
 {
-    //Got an initial scan laser, obtain its parametes
-    ROS_INFO_COND(verbose, "[rf2o] Got first Laser Scan .... Configuring node");
+  //Got an initial scan laser, obtain its parametes
+  ROS_INFO_COND(verbose, "[rf2o] Got first Laser Scan .... Configuring node");
 
-    width = scan.ranges.size();    // Num of samples (size) of the scan laser
+  width = scan.ranges.size();    // Num of samples (size) of the scan laser
 
-    cols = width;						// Max reolution. Should be similar to the width parameter
-    fovh = fabs(scan.angle_max - scan.angle_min); // Horizontal Laser's FOV
-    ctf_levels = 5;                     // Coarse-to-Fine levels
-    iter_irls = 5;                      //Num iterations to solve iterative reweighted least squares
+  cols = width;						// Max reolution. Should be similar to the width parameter
+  fovh = fabs(scan.angle_max - scan.angle_min); // Horizontal Laser's FOV
+  ctf_levels = 5;                     // Coarse-to-Fine levels
+  iter_irls = 5;                      //Num iterations to solve iterative reweighted least squares
 
-    Pose3d robotInitialPose = Pose3d::Identity();
-    const geometry_msgs::Pose _src = initial_robot_pose;
+  Pose3d robotInitialPose = Pose3d::Identity();
+  const geometry_msgs::Pose _src = initial_robot_pose;
 
-    robotInitialPose = Eigen::Quaterniond(_src.orientation.w,
-                                          _src.orientation.x,
-                                          _src.orientation.y,
-                                          _src.orientation.z);
+  robotInitialPose = Eigen::Quaterniond(_src.orientation.w,
+                                        _src.orientation.x,
+                                        _src.orientation.y,
+                                        _src.orientation.z);
 
-    robotInitialPose.translation()(0) = _src.position.x;
-    robotInitialPose.translation()(1) = _src.position.y;
+  robotInitialPose.translation()(0) = _src.position.x;
+  robotInitialPose.translation()(1) = _src.position.y;
 
-    //Set the initial pose
-    laser_pose_    = robotInitialPose * laser_pose_on_robot_;
-    laser_oldpose_ = laser_oldpose_;
+  //Set the initial pose
+  laser_pose_    = robotInitialPose * laser_pose_on_robot_;
+  laser_oldpose_ = laser_oldpose_;
 
-    // Init module (internal)
-    //------------------------
-    range_wf = Eigen::MatrixXf::Constant(1, width, 1);
+  // Init module (internal)
+  //------------------------
+  range_wf = Eigen::MatrixXf::Constant(1, width, 1);
 
-    //Resize vectors according to levels
-    transformations.resize(ctf_levels);
-    for (unsigned int i = 0; i < ctf_levels; i++)
-        transformations[i].resize(3, 3);
+  //Resize vectors according to levels
+  transformations.resize(ctf_levels);
+  for (unsigned int i = 0; i < ctf_levels; i++)
+    transformations[i].resize(3, 3);
 
-    //Resize pyramid
-    unsigned int s, cols_i;
-    const unsigned int pyr_levels = std::round(std::log2(round(float(width) / float(cols)))) + ctf_levels;
-    range.resize(pyr_levels);
-    range_old.resize(pyr_levels);
-    range_inter.resize(pyr_levels);
-    xx.resize(pyr_levels);
-    xx_inter.resize(pyr_levels);
-    xx_old.resize(pyr_levels);
-    yy.resize(pyr_levels);
-    yy_inter.resize(pyr_levels);
-    yy_old.resize(pyr_levels);
-    range_warped.resize(pyr_levels);
-    xx_warped.resize(pyr_levels);
-    yy_warped.resize(pyr_levels);
+  //Resize pyramid
+  unsigned int s, cols_i;
+  const unsigned int pyr_levels = std::round(std::log2(round(float(width) / float(cols)))) + ctf_levels;
+  range.resize(pyr_levels);
+  range_old.resize(pyr_levels);
+  range_inter.resize(pyr_levels);
+  xx.resize(pyr_levels);
+  xx_inter.resize(pyr_levels);
+  xx_old.resize(pyr_levels);
+  yy.resize(pyr_levels);
+  yy_inter.resize(pyr_levels);
+  yy_old.resize(pyr_levels);
+  range_warped.resize(pyr_levels);
+  xx_warped.resize(pyr_levels);
+  yy_warped.resize(pyr_levels);
 
-    for (unsigned int i = 0; i < pyr_levels; i++)
+  for (unsigned int i = 0; i < pyr_levels; i++)
+  {
+    s = std::pow(2.f, int(i));
+    cols_i = std::ceil(float(width) / float(s));
+
+    range[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
+    range_old[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
+    range_inter[i].resize(1, cols_i);
+
+    xx[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
+    xx_old[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
+
+    yy[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
+    yy_old[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
+
+    xx_inter[i].resize(1, cols_i);
+    yy_inter[i].resize(1, cols_i);
+
+    if (cols_i <= cols)
     {
-        s = std::pow(2.f, int(i));
-        cols_i = std::ceil(float(width) / float(s));
-
-        range[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
-        range_old[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
-        range_inter[i].resize(1, cols_i);
-
-        xx[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
-        xx_old[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
-
-        yy[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
-        yy_old[i] = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
-
-        xx_inter[i].resize(1, cols_i);
-        yy_inter[i].resize(1, cols_i);
-
-        if (cols_i <= cols)
-        {
-            range_warped[i].resize(1, cols_i);
-            xx_warped[i].resize(1, cols_i);
-            yy_warped[i].resize(1, cols_i);
-        }
+      range_warped[i].resize(1, cols_i);
+      xx_warped[i].resize(1, cols_i);
+      yy_warped[i].resize(1, cols_i);
     }
+  }
 
-    dt.resize(1, cols);
-    dtita.resize(1, cols);
-    normx.resize(1, cols);
-    normy.resize(1, cols);
-    norm_ang.resize(1, cols);
-    weights.resize(1, cols);
+  dt.resize(1, cols);
+  dtita.resize(1, cols);
+  normx.resize(1, cols);
+  normy.resize(1, cols);
+  norm_ang.resize(1, cols);
+  weights.resize(1, cols);
 
-    null = Eigen::MatrixXi::Constant(1, cols, 0);
-    cov_odo = IncrementCov::Zero();
+  null = Eigen::MatrixXi::Constant(1, cols, 0);
+  cov_odo = IncrementCov::Zero();
 
-    fps = 1.f;		//In Hz
-    num_valid_range = 0;
+  fps = 1.f;		//In Hz
+  num_valid_range = 0;
 
-    //Compute gaussian mask
-    g_mask[0] = 1.f / 16.f; g_mask[1] = 0.25f; g_mask[2] = 6.f / 16.f; g_mask[3] = g_mask[1]; g_mask[4] = g_mask[0];
+  //Compute gaussian mask
+  g_mask[0] = 1.f / 16.f; g_mask[1] = 0.25f; g_mask[2] = 6.f / 16.f; g_mask[3] = g_mask[1]; g_mask[4] = g_mask[0];
 
-    kai_abs_ = MatrixS31::Zero();
-    kai_loc_old_ = MatrixS31::Zero();
+  kai_abs_ = MatrixS31::Zero();
+  kai_loc_old_ = MatrixS31::Zero();
 
-    module_initialized = true;
-    last_odom_time = ros::Time::now();
+  module_initialized = true;
+  last_odom_time = ros::Time::now();
 }
 
 const CLaserOdometry2D::Pose3d& CLaserOdometry2D::getIncrement() const
@@ -163,328 +165,323 @@ const CLaserOdometry2D::Pose3d& CLaserOdometry2D::getPose() const
 
 bool CLaserOdometry2D::odometryCalculation(const sensor_msgs::LaserScan& scan)
 {
-    //==================================================================================
-    //						DIFERENTIAL  ODOMETRY  MULTILEVEL
-    //==================================================================================
+  //==================================================================================
+  //						DIFERENTIAL  ODOMETRY  MULTILEVEL
+  //==================================================================================
 
-    //copy laser scan to internal variable
-    for (unsigned int i = 0; i<width; i++)
-        range_wf(i) = scan.ranges[i];
+  //copy laser scan to internal variable
+  for (unsigned int i = 0; i<width; i++)
+    range_wf(i) = scan.ranges[i];
 
-    ros::WallTime start = ros::WallTime::now();
+  ros::WallTime start = ros::WallTime::now();
 
-    createImagePyramid();
+  createImagePyramid();
 
-    //Coarse-to-fine scheme
-    for (unsigned int i=0; i<ctf_levels; i++)
+  //Coarse-to-fine scheme
+  for (unsigned int i=0; i<ctf_levels; i++)
+  {
+    //Previous computations
+    transformations[i].setIdentity();
+
+    level = i;
+    unsigned int s = std::pow(2.f,int(ctf_levels-(i+1)));
+    cols_i = std::ceil(float(cols)/float(s));
+    image_level = ctf_levels - i + std::round(std::log2(std::round(float(width)/float(cols)))) - 1;
+
+    //1. Perform warping
+    if (i == 0)
     {
-        //Previous computations
-        transformations[i].setIdentity();
+      range_warped[image_level] = range[image_level];
+      xx_warped[image_level] = xx[image_level];
+      yy_warped[image_level] = yy[image_level];
+    }
+    else
+      performWarping();
 
-        level = i;
-        unsigned int s = std::pow(2.f,int(ctf_levels-(i+1)));
-        cols_i = std::ceil(float(cols)/float(s));
-        image_level = ctf_levels - i + std::round(std::log2(std::round(float(width)/float(cols)))) - 1;
+    //2. Calculate inter coords
+    calculateCoord();
 
-        //1. Perform warping
-        if (i == 0)
-        {
-            range_warped[image_level] = range[image_level];
-            xx_warped[image_level] = xx[image_level];
-            yy_warped[image_level] = yy[image_level];
-        }
-        else
-            performWarping();
+    //3. Find null points
+    findNullPoints();
 
-        //2. Calculate inter coords
-        calculateCoord();
+    //4. Compute derivatives
+    calculaterangeDerivativesSurface();
 
-        //3. Find null points
-        findNullPoints();
+    //5. Compute normals
+    //computeNormals();
 
-        //4. Compute derivatives
-        calculaterangeDerivativesSurface();
+    //6. Compute weights
+    computeWeights();
 
-        //5. Compute normals
-        //computeNormals();
-
-        //6. Compute weights
-        computeWeights();
-
-        //7. Solve odometry
-        if (num_valid_range > 3)
-        {
-            solveSystemNonLinear();
-            //solveSystemOneLevel();    //without robust-function
-        }
-
-        //8. Filter solution
-        filterLevelSolution();
-
+    //7. Solve odometry
+    if (num_valid_range > 3)
+    {
+      solveSystemNonLinear();
+      //solveSystemOneLevel();    //without robust-function
     }
 
-    m_runtime = ros::WallTime::now() - start;
+    //8. Filter solution
+    filterLevelSolution();
 
-    ROS_INFO_COND(verbose, "[rf2o] execution time (ms): %f",
-                  m_runtime.toSec()*double(1000));
+  }
 
-    //Update poses
-    PoseUpdate();
+  m_runtime = ros::WallTime::now() - start;
 
-    return true;
+  ROS_INFO_COND(verbose, "[rf2o] execution time (ms): %f",
+                m_runtime.toSec()*double(1000));
+
+  //Update poses
+  PoseUpdate();
+
+  return true;
 }
-
 
 void CLaserOdometry2D::createImagePyramid()
 {
-	const float max_range_dif = 0.3f;
+  const float max_range_dif = 0.3f;
 
-	//Push the frames back
-	range_old.swap(range);
-	xx_old.swap(xx);
-	yy_old.swap(yy);
+  //Push the frames back
+  range_old.swap(range);
+  xx_old.swap(xx);
+  yy_old.swap(yy);
 
-    //The number of levels of the pyramid does not match the number of levels used
-    //in the odometry computation (because we sometimes want to finish with lower resolutions)
+  //The number of levels of the pyramid does not match the number of levels used
+  //in the odometry computation (because we sometimes want to finish with lower resolutions)
 
-    unsigned int pyr_levels = std::round(std::log2(std::round(float(width)/float(cols)))) + ctf_levels;
+  unsigned int pyr_levels = std::round(std::log2(std::round(float(width)/float(cols)))) + ctf_levels;
 
-    //Generate levels
-    for (unsigned int i = 0; i<pyr_levels; i++)
+  //Generate levels
+  for (unsigned int i = 0; i<pyr_levels; i++)
+  {
+    unsigned int s = std::pow(2.f,int(i));
+    cols_i = std::ceil(float(width)/float(s));
+
+    const unsigned int i_1 = i-1;
+
+    //First level -> Filter (not downsampling);
+    if (i == 0)
     {
-        unsigned int s = std::pow(2.f,int(i));
-        cols_i = std::ceil(float(width)/float(s));
+      for (unsigned int u = 0; u < cols_i; u++)
+      {
+        const float dcenter = range_wf(u);
 
-		const unsigned int i_1 = i-1;
-
-		//First level -> Filter (not downsampling);
-        if (i == 0)
-		{
-			for (unsigned int u = 0; u < cols_i; u++)
-            {
-				const float dcenter = range_wf(u);
-
-				//Inner pixels
-                if ((u>1)&&(u<cols_i-2))
-                {
-					if (dcenter > 0.f)
-					{
-						float sum = 0.f;
-						float weight = 0.f;
-
-						for (int l=-2; l<3; l++)
-						{
-              const float abs_dif = std::abs(range_wf(u+l)-dcenter);
-							if (abs_dif < max_range_dif)
-							{
-								const float aux_w = g_mask[2+l]*(max_range_dif - abs_dif);
-								weight += aux_w;
-								sum += aux_w*range_wf(u+l);
-							}
-						}
-						range[i](u) = sum/weight;
-					}
-					else
-						range[i](u) = 0.f;
-
-                }
-
-                //Boundary
-                else
-                {
-                    if (dcenter > 0.f)
-					{
-						float sum = 0.f;
-						float weight = 0.f;
-
-						for (int l=-2; l<3; l++)
-						{
-							const int indu = u+l;
-							if ((indu>=0)&&(indu<cols_i))
-							{
-                const float abs_dif = std::abs(range_wf(indu)-dcenter);
-								if (abs_dif < max_range_dif)
-								{
-									const float aux_w = g_mask[2+l]*(max_range_dif - abs_dif);
-									weight += aux_w;
-									sum += aux_w*range_wf(indu);
-								}
-							}
-						}
-						range[i](u) = sum/weight;
-					}
-					else
-						range[i](u) = 0.f;
-
-                }
-            }
-		}
-
-        //                              Downsampling
-        //-----------------------------------------------------------------------------
-        else
+        //Inner pixels
+        if ((u>1)&&(u<cols_i-2))
         {
-			for (unsigned int u = 0; u < cols_i; u++)
+          if (dcenter > 0.f)
+          {
+            float sum = 0.f;
+            float weight = 0.f;
+
+            for (int l=-2; l<3; l++)
             {
-                const int u2 = 2*u;
-				const float dcenter = range[i_1](u2);
-
-				//Inner pixels
-                if ((u>0)&&(u<cols_i-1))
-                {
-					if (dcenter > 0.f)
-					{
-						float sum = 0.f;
-						float weight = 0.f;
-
-						for (int l=-2; l<3; l++)
-						{
-              const float abs_dif = std::abs(range[i_1](u2+l)-dcenter);
-							if (abs_dif < max_range_dif)
-							{
-								const float aux_w = g_mask[2+l]*(max_range_dif - abs_dif);
-								weight += aux_w;
-								sum += aux_w*range[i_1](u2+l);
-							}
-						}
-						range[i](u) = sum/weight;
-					}
-					else
-						range[i](u) = 0.f;
-
-                }
-
-                //Boundary
-                else
-                {
-                    if (dcenter > 0.f)
-					{
-						float sum = 0.f;
-						float weight = 0.f;
-						const unsigned int cols_i2 = range[i_1].cols();
-
-
-						for (int l=-2; l<3; l++)
-						{
-							const int indu = u2+l;
-							if ((indu>=0)&&(indu<cols_i2))
-							{
-                const float abs_dif = std::abs(range[i_1](indu)-dcenter);
-								if (abs_dif < max_range_dif)
-								{
-									const float aux_w = g_mask[2+l]*(max_range_dif - abs_dif);
-									weight += aux_w;
-									sum += aux_w*range[i_1](indu);
-								}
-							}
-						}
-						range[i](u) = sum/weight;
-					}
-					else
-						range[i](u) = 0.f;
-
-                }
+              const float abs_dif = std::abs(range_wf(u+l)-dcenter);
+              if (abs_dif < max_range_dif)
+              {
+                const float aux_w = g_mask[2+l]*(max_range_dif - abs_dif);
+                weight += aux_w;
+                sum += aux_w*range_wf(u+l);
+              }
             }
+            range[i](u) = sum/weight;
+          }
+          else
+            range[i](u) = 0.f;
+
         }
 
-        //Calculate coordinates "xy" of the points
-        for (unsigned int u = 0; u < cols_i; u++)
-		{
-            if (range[i](u) > 0.f)
-			{
-				const float tita = -0.5*fovh + float(u)*fovh/float(cols_i-1);
+        //Boundary
+        else
+        {
+          if (dcenter > 0.f)
+          {
+            float sum = 0.f;
+            float weight = 0.f;
+
+            for (int l=-2; l<3; l++)
+            {
+              const int indu = u+l;
+              if ((indu>=0)&&(indu<cols_i))
+              {
+                const float abs_dif = std::abs(range_wf(indu)-dcenter);
+                if (abs_dif < max_range_dif)
+                {
+                  const float aux_w = g_mask[2+l]*(max_range_dif - abs_dif);
+                  weight += aux_w;
+                  sum += aux_w*range_wf(indu);
+                }
+              }
+            }
+            range[i](u) = sum/weight;
+          }
+          else
+            range[i](u) = 0.f;
+
+        }
+      }
+    }
+
+    //                              Downsampling
+    //-----------------------------------------------------------------------------
+    else
+    {
+      for (unsigned int u = 0; u < cols_i; u++)
+      {
+        const int u2 = 2*u;
+        const float dcenter = range[i_1](u2);
+
+        //Inner pixels
+        if ((u>0)&&(u<cols_i-1))
+        {
+          if (dcenter > 0.f)
+          {
+            float sum = 0.f;
+            float weight = 0.f;
+
+            for (int l=-2; l<3; l++)
+            {
+              const float abs_dif = std::abs(range[i_1](u2+l)-dcenter);
+              if (abs_dif < max_range_dif)
+              {
+                const float aux_w = g_mask[2+l]*(max_range_dif - abs_dif);
+                weight += aux_w;
+                sum += aux_w*range[i_1](u2+l);
+              }
+            }
+            range[i](u) = sum/weight;
+          }
+          else
+            range[i](u) = 0.f;
+
+        }
+
+        //Boundary
+        else
+        {
+          if (dcenter > 0.f)
+          {
+            float sum = 0.f;
+            float weight = 0.f;
+            const unsigned int cols_i2 = range[i_1].cols();
+
+
+            for (int l=-2; l<3; l++)
+            {
+              const int indu = u2+l;
+              if ((indu>=0)&&(indu<cols_i2))
+              {
+                const float abs_dif = std::abs(range[i_1](indu)-dcenter);
+                if (abs_dif < max_range_dif)
+                {
+                  const float aux_w = g_mask[2+l]*(max_range_dif - abs_dif);
+                  weight += aux_w;
+                  sum += aux_w*range[i_1](indu);
+                }
+              }
+            }
+            range[i](u) = sum/weight;
+          }
+          else
+            range[i](u) = 0.f;
+
+        }
+      }
+    }
+
+    //Calculate coordinates "xy" of the points
+    for (unsigned int u = 0; u < cols_i; u++)
+    {
+      if (range[i](u) > 0.f)
+      {
+        const float tita = -0.5*fovh + float(u)*fovh/float(cols_i-1);
         xx[i](u) = range[i](u)*std::cos(tita);
         yy[i](u) = range[i](u)*std::sin(tita);
-			}
-			else
-			{
-				xx[i](u) = 0.f;
-				yy[i](u) = 0.f;
-			}
-		}
+      }
+      else
+      {
+        xx[i](u) = 0.f;
+        yy[i](u) = 0.f;
+      }
     }
+  }
 }
-
-
 
 void CLaserOdometry2D::calculateCoord()
 {
-	for (unsigned int u = 0; u < cols_i; u++)
-	{
-		if ((range_old[image_level](u) == 0.f) || (range_warped[image_level](u) == 0.f))
-		{
-			range_inter[image_level](u) = 0.f;
-			xx_inter[image_level](u) = 0.f;
-			yy_inter[image_level](u) = 0.f;
-		}
-		else
-		{
-			range_inter[image_level](u) = 0.5f*(range_old[image_level](u) + range_warped[image_level](u));
-			xx_inter[image_level](u) = 0.5f*(xx_old[image_level](u) + xx_warped[image_level](u));
-			yy_inter[image_level](u) = 0.5f*(yy_old[image_level](u) + yy_warped[image_level](u));
-		}
-	}
+  for (unsigned int u = 0; u < cols_i; u++)
+  {
+    if ((range_old[image_level](u) == 0.f) || (range_warped[image_level](u) == 0.f))
+    {
+      range_inter[image_level](u) = 0.f;
+      xx_inter[image_level](u) = 0.f;
+      yy_inter[image_level](u) = 0.f;
+    }
+    else
+    {
+      range_inter[image_level](u) = 0.5f*(range_old[image_level](u) + range_warped[image_level](u));
+      xx_inter[image_level](u) = 0.5f*(xx_old[image_level](u) + xx_warped[image_level](u));
+      yy_inter[image_level](u) = 0.5f*(yy_old[image_level](u) + yy_warped[image_level](u));
+    }
+  }
 }
-
 
 void CLaserOdometry2D::calculaterangeDerivativesSurface()
 {
-	//The gradient size ir reserved at the maximum size (at the constructor)
+  //The gradient size ir reserved at the maximum size (at the constructor)
 
-    //Compute connectivity
+  //Compute connectivity
 
   //Defined in a different way now, without inversion
   rtita = Eigen::MatrixXf::Constant(1, cols_i, 1.f);
 
-	for (unsigned int u = 0; u < cols_i-1; u++)
-    {
+  for (unsigned int u = 0; u < cols_i-1; u++)
+  {
     float dista = xx_inter[image_level](u+1) - xx_inter[image_level](u);
     dista *= dista;
     float distb = yy_inter[image_level](u+1) - yy_inter[image_level](u);
     distb *= distb;
     const float dist = dista + distb;
 
-		if (dist  > 0.f)
+    if (dist  > 0.f)
       rtita(u) = std::sqrt(dist);
-	}
+  }
 
-    //Spatial derivatives
-    for (unsigned int u = 1; u < cols_i-1; u++)
+  //Spatial derivatives
+  for (unsigned int u = 1; u < cols_i-1; u++)
     dtita(u) = (rtita(u-1)*(range_inter[image_level](u+1)-
                 range_inter[image_level](u)) + rtita(u)*(range_inter[image_level](u) -
-                range_inter[image_level](u-1)))/(rtita(u)+rtita(u-1));
+        range_inter[image_level](u-1)))/(rtita(u)+rtita(u-1));
 
-	dtita(0) = dtita(1);
-	dtita(cols_i-1) = dtita(cols_i-2);
+  dtita(0) = dtita(1);
+  dtita(cols_i-1) = dtita(cols_i-2);
 
-	//Temporal derivative
-	for (unsigned int u = 0; u < cols_i; u++)
-		dt(u) = fps*(range_warped[image_level](u) - range_old[image_level](u));
+  //Temporal derivative
+  for (unsigned int u = 0; u < cols_i; u++)
+    dt(u) = fps*(range_warped[image_level](u) - range_old[image_level](u));
 
 
-	//Apply median filter to the range derivatives
-	//MatrixXf dtitamed = dtita, dtmed = dt;
-	//vector<float> svector(3);
-	//for (unsigned int u=1; u<cols_i-1; u++)
-	//{
-	//	svector.at(0) = dtita(u-1); svector.at(1) = dtita(u); svector.at(2) = dtita(u+1);
-	//	std::sort(svector.begin(), svector.end());
-	//	dtitamed(u) = svector.at(1);
+  //Apply median filter to the range derivatives
+  //MatrixXf dtitamed = dtita, dtmed = dt;
+  //vector<float> svector(3);
+  //for (unsigned int u=1; u<cols_i-1; u++)
+  //{
+  //	svector.at(0) = dtita(u-1); svector.at(1) = dtita(u); svector.at(2) = dtita(u+1);
+  //	std::sort(svector.begin(), svector.end());
+  //	dtitamed(u) = svector.at(1);
 
-	//	svector.at(0) = dt(u-1); svector.at(1) = dt(u); svector.at(2) = dt(u+1);
-	//	std::sort(svector.begin(), svector.end());
-	//	dtmed(u) = svector.at(1);
-	//}
+  //	svector.at(0) = dt(u-1); svector.at(1) = dt(u); svector.at(2) = dt(u+1);
+  //	std::sort(svector.begin(), svector.end());
+  //	dtmed(u) = svector.at(1);
+  //}
 
-	//dtitamed(0) = dtitamed(1);
-	//dtitamed(cols_i-1) = dtitamed(cols_i-2);
-	//dtmed(0) = dtmed(1);
-	//dtmed(cols_i-1) = dtmed(cols_i-2);
+  //dtitamed(0) = dtitamed(1);
+  //dtitamed(cols_i-1) = dtitamed(cols_i-2);
+  //dtmed(0) = dtmed(1);
+  //dtmed(cols_i-1) = dtmed(cols_i-2);
 
-	//dtitamed.swap(dtita);
-	//dtmed.swap(dt);
+  //dtitamed.swap(dtita);
+  //dtmed.swap(dt);
 }
-
 
 void CLaserOdometry2D::computeNormals()
 {
@@ -492,78 +489,75 @@ void CLaserOdometry2D::computeNormals()
   normy.setConstant(1, cols, 0.f);
   norm_ang.setConstant(1, cols, 0.f);
 
-	const float incr_tita = fovh/float(cols_i-1);
-	for (unsigned int u=0; u<cols_i; u++)
-	{
-		if (null(u) == 0.f)
-		{
-			const float tita = -0.5f*fovh + float(u)*incr_tita;
+  const float incr_tita = fovh/float(cols_i-1);
+  for (unsigned int u=0; u<cols_i; u++)
+  {
+    if (null(u) == 0.f)
+    {
+      const float tita = -0.5f*fovh + float(u)*incr_tita;
       const float alfa = -std::atan2(2.f*dtita(u), 2.f*range[image_level](u)*incr_tita);
-			norm_ang(u) = tita + alfa;
-			if (norm_ang(u) < -M_PI)
-				norm_ang(u) += 2.f*M_PI;
-			else if (norm_ang(u) < 0.f)
-				norm_ang(u) += M_PI;
-			else if (norm_ang(u) > M_PI)
-				norm_ang(u) -= M_PI;
+      norm_ang(u) = tita + alfa;
+      if (norm_ang(u) < -M_PI)
+        norm_ang(u) += 2.f*M_PI;
+      else if (norm_ang(u) < 0.f)
+        norm_ang(u) += M_PI;
+      else if (norm_ang(u) > M_PI)
+        norm_ang(u) -= M_PI;
 
       normx(u) = std::cos(tita + alfa);
       normy(u) = std::sin(tita + alfa);
-		}
-	}
+    }
+  }
 }
-
 
 void CLaserOdometry2D::computeWeights()
 {
-	//The maximum weight size is reserved at the constructor
+  //The maximum weight size is reserved at the constructor
   weights.setConstant(1, cols, 0.f);
 
-	//Parameters for error_linearization
-	const float kdtita = 1.f;
+  //Parameters for error_linearization
+  const float kdtita = 1.f;
   const float kdt = kdtita / (fps*fps);
-	const float k2d = 0.2f;
+  const float k2d = 0.2f;
 
-	for (unsigned int u = 1; u < cols_i-1; u++)
-		if (null(u) == 0)
-		{
-			//							Compute derivatives
-			//-----------------------------------------------------------------------
-			const float ini_dtita = range_old[image_level](u+1) - range_old[image_level](u-1);
-			const float final_dtita = range_warped[image_level](u+1) - range_warped[image_level](u-1);
+  for (unsigned int u = 1; u < cols_i-1; u++)
+    if (null(u) == 0)
+    {
+      //							Compute derivatives
+      //-----------------------------------------------------------------------
+      const float ini_dtita = range_old[image_level](u+1) - range_old[image_level](u-1);
+      const float final_dtita = range_warped[image_level](u+1) - range_warped[image_level](u-1);
 
-			const float dtitat = ini_dtita - final_dtita;
-			const float dtita2 = dtita(u+1) - dtita(u-1);
+      const float dtitat = ini_dtita - final_dtita;
+      const float dtita2 = dtita(u+1) - dtita(u-1);
 
       const float w_der = kdt*(dt(u)*dt(u)) +
-                           kdtita*(dtita(u)*dtita(u)) +
-                            k2d*(std::abs(dtitat) + std::abs(dtita2));
+          kdtita*(dtita(u)*dtita(u)) +
+          k2d*(std::abs(dtitat) + std::abs(dtita2));
 
       weights(u) = std::sqrt(1.f/w_der);
-		}
+    }
 
   const float inv_max = 1.f / weights.maxCoeff();
-	weights = inv_max*weights;
+  weights = inv_max*weights;
 }
-
 
 void CLaserOdometry2D::findNullPoints()
 {
-	//Size of null matrix is set to its maximum size (constructor)
-	num_valid_range = 0;
+  //Size of null matrix is set to its maximum size (constructor)
+  num_valid_range = 0;
 
-	for (unsigned int u = 1; u < cols_i-1; u++)
-	{
-		if (range_inter[image_level](u) == 0.f)
-			null(u) = 1;
-		else
-		{
-			num_valid_range++;
-			null(u) = 0;
-		}
-	}
+  for (unsigned int u = 1; u < cols_i-1; u++)
+  {
+    if (range_inter[image_level](u) == 0.f)
+      null(u) = 1;
+    else
+    {
+      num_valid_range++;
+      null(u) = 0;
+    }
+  }
 }
-
 
 // Solves the system without considering any robust-function
 void CLaserOdometry2D::solveSystemOneLevel()
@@ -571,320 +565,313 @@ void CLaserOdometry2D::solveSystemOneLevel()
   A.resize(num_valid_range, 3);
   B.resize(num_valid_range, 1);
 
-	unsigned int cont = 0;
-	const float kdtita = (cols_i-1)/fovh;
+  unsigned int cont = 0;
+  const float kdtita = (cols_i-1)/fovh;
 
-	//Fill the matrix A and the vector B
-	//The order of the variables will be (vx, vy, wz)
+  //Fill the matrix A and the vector B
+  //The order of the variables will be (vx, vy, wz)
 
-	for (unsigned int u = 1; u < cols_i-1; u++)
-		if (null(u) == 0)
-		{
-			// Precomputed expressions
-			const float tw = weights(u);
-			const float tita = -0.5*fovh + u/kdtita;
+  for (unsigned int u = 1; u < cols_i-1; u++)
+    if (null(u) == 0)
+    {
+      // Precomputed expressions
+      const float tw = weights(u);
+      const float tita = -0.5*fovh + u/kdtita;
 
-			//Fill the matrix A
+      //Fill the matrix A
       A(cont, 0) = tw*(std::cos(tita) + dtita(u)*kdtita*std::sin(tita)/range_inter[image_level](u));
       A(cont, 1) = tw*(std::sin(tita) - dtita(u)*kdtita*std::cos(tita)/range_inter[image_level](u));
       A(cont, 2) = tw*(-yy[image_level](u)*std::cos(tita) + xx[image_level](u)*std::sin(tita) - dtita(u)*kdtita);
       B(cont, 0) = tw*(-dt(u));
 
-			cont++;
-		}
+      cont++;
+    }
 
-	//Solve the linear system of equations using a minimum least squares method
+  //Solve the linear system of equations using a minimum least squares method
   Eigen::MatrixXf AtA, AtB;
   AtA = A.transpose()*A;
   AtB = A.transpose()*B;
-	Var = AtA.ldlt().solve(AtB);
+  Var = AtA.ldlt().solve(AtB);
 
-	//Covariance matrix calculation 	Cov Order -> vx,vy,wz
+  //Covariance matrix calculation 	Cov Order -> vx,vy,wz
   Eigen::MatrixXf res(num_valid_range,1);
-	res = A*Var - B;
-	cov_odo = (1.f/float(num_valid_range-3))*AtA.inverse()*res.squaredNorm();
+  res = A*Var - B;
+  cov_odo = (1.f/float(num_valid_range-3))*AtA.inverse()*res.squaredNorm();
 
   kai_loc_level_ = Var;
 }
 
-
 // Solves the system by considering the Cauchy M-estimator robust-function
 void CLaserOdometry2D::solveSystemNonLinear()
 {
-    A.resize(num_valid_range, 3); Aw.resize(num_valid_range, 3);
-    B.resize(num_valid_range, 1); Bw.resize(num_valid_range, 1);
-    unsigned int cont = 0;
-    const float kdtita = float(cols_i-1)/fovh;
+  A.resize(num_valid_range, 3); Aw.resize(num_valid_range, 3);
+  B.resize(num_valid_range, 1); Bw.resize(num_valid_range, 1);
+  unsigned int cont = 0;
+  const float kdtita = float(cols_i-1)/fovh;
 
-    //Fill the matrix A and the vector B
-    //The order of the variables will be (vx, vy, wz)
+  //Fill the matrix A and the vector B
+  //The order of the variables will be (vx, vy, wz)
 
-    for (unsigned int u = 1; u < cols_i-1; u++)
-        if (null(u) == 0)
-        {
-            // Precomputed expressions
-            const float tw = weights(u);
-            const float tita = -0.5*fovh + u/kdtita;
-
-            //Fill the matrix A
-            A(cont, 0) = tw*(std::cos(tita) + dtita(u)*kdtita*std::sin(tita)/range_inter[image_level](u));
-            A(cont, 1) = tw*(std::sin(tita) - dtita(u)*kdtita*std::cos(tita)/range_inter[image_level](u));
-            A(cont, 2) = tw*(-yy[image_level](u)*std::cos(tita) + xx[image_level](u)*std::sin(tita) - dtita(u)*kdtita);
-            B(cont, 0) = tw*(-dt(u));
-
-            cont++;
-        }
-
-    //Solve the linear system of equations using a minimum least squares method
-    Eigen::MatrixXf AtA, AtB;
-    AtA = A.transpose()*A;
-    AtB = A.transpose()*B;
-    Var = AtA.ldlt().solve(AtB);
-
-    //Covariance matrix calculation 	Cov Order -> vx,vy,wz
-    Eigen::MatrixXf res(num_valid_range,1);
-    res = A*Var - B;
-    //cout << endl << "max res: " << res.maxCoeff();
-    //cout << endl << "min res: " << res.minCoeff();
-
-    ////Compute the energy
-    //Compute the average dt
-    float aver_dt = 0.f, aver_res = 0.f; unsigned int ind = 0;
-    for (unsigned int u = 1; u < cols_i-1; u++)
-        if (null(u) == 0)
-        {
-            aver_dt  += std::abs(dt(u));
-            aver_res += std::abs(res(ind++));
-        }
-    aver_dt /= cont; aver_res /= cont;
-//    printf("\n Aver dt = %f, aver res = %f", aver_dt, aver_res);
-
-
-    const float k = 10.f/aver_dt; //200
-    //float energy = 0.f;
-    //for (unsigned int i=0; i<res.rows(); i++)
-    //	energy += log(1.f + mrpt::math::square(k*res(i)));
-    //printf("\n\nEnergy(0) = %f", energy);
-
-    //Solve iterative reweighted least squares
-    //===================================================================
-    for (unsigned int i=1; i<=iter_irls; i++)
+  for (unsigned int u = 1; u < cols_i-1; u++)
+    if (null(u) == 0)
     {
-        cont = 0;
+      // Precomputed expressions
+      const float tw = weights(u);
+      const float tita = -0.5*fovh + u/kdtita;
 
-        for (unsigned int u = 1; u < cols_i-1; u++)
-            if (null(u) == 0)
-            {
-                const float res_weight = std::sqrt(1.f/(1.f + ((k*res(cont))*(k*res(cont)))));
+      //Fill the matrix A
+      A(cont, 0) = tw*(std::cos(tita) + dtita(u)*kdtita*std::sin(tita)/range_inter[image_level](u));
+      A(cont, 1) = tw*(std::sin(tita) - dtita(u)*kdtita*std::cos(tita)/range_inter[image_level](u));
+      A(cont, 2) = tw*(-yy[image_level](u)*std::cos(tita) + xx[image_level](u)*std::sin(tita) - dtita(u)*kdtita);
+      B(cont, 0) = tw*(-dt(u));
 
-                //Fill the matrix Aw
-                Aw(cont,0) = res_weight*A(cont,0);
-                Aw(cont,1) = res_weight*A(cont,1);
-                Aw(cont,2) = res_weight*A(cont,2);
-                Bw(cont)   = res_weight*B(cont);
-                cont++;
-            }
-
-        //Solve the linear system of equations using a minimum least squares method
-        AtA = Aw.transpose()*Aw;
-        AtB = Aw.transpose()*Bw;
-        Var = AtA.ldlt().solve(AtB);
-        res = A*Var - B;
-
-        ////Compute the energy
-        //energy = 0.f;
-        //for (unsigned int j=0; j<res.rows(); j++)
-        //	energy += log(1.f + mrpt::math::square(k*res(j)));
-        //printf("\nEnergy(%d) = %f", i, energy);
+      cont++;
     }
 
-    cov_odo = (1.f/float(num_valid_range-3))*AtA.inverse()*res.squaredNorm();
-    kai_loc_level_ = Var;
+  //Solve the linear system of equations using a minimum least squares method
+  Eigen::MatrixXf AtA, AtB;
+  AtA = A.transpose()*A;
+  AtB = A.transpose()*B;
+  Var = AtA.ldlt().solve(AtB);
 
-    ROS_INFO_STREAM_COND(verbose, "[rf2o] COV_ODO:\n" << cov_odo);
+  //Covariance matrix calculation 	Cov Order -> vx,vy,wz
+  Eigen::MatrixXf res(num_valid_range,1);
+  res = A*Var - B;
+  //cout << endl << "max res: " << res.maxCoeff();
+  //cout << endl << "min res: " << res.minCoeff();
+
+  ////Compute the energy
+  //Compute the average dt
+  float aver_dt = 0.f, aver_res = 0.f; unsigned int ind = 0;
+  for (unsigned int u = 1; u < cols_i-1; u++)
+    if (null(u) == 0)
+    {
+      aver_dt  += std::abs(dt(u));
+      aver_res += std::abs(res(ind++));
+    }
+  aver_dt /= cont; aver_res /= cont;
+  //    printf("\n Aver dt = %f, aver res = %f", aver_dt, aver_res);
+
+
+  const float k = 10.f/aver_dt; //200
+  //float energy = 0.f;
+  //for (unsigned int i=0; i<res.rows(); i++)
+  //	energy += log(1.f + mrpt::math::square(k*res(i)));
+  //printf("\n\nEnergy(0) = %f", energy);
+
+  //Solve iterative reweighted least squares
+  //===================================================================
+  for (unsigned int i=1; i<=iter_irls; i++)
+  {
+    cont = 0;
+
+    for (unsigned int u = 1; u < cols_i-1; u++)
+      if (null(u) == 0)
+      {
+        const float res_weight = std::sqrt(1.f/(1.f + ((k*res(cont))*(k*res(cont)))));
+
+        //Fill the matrix Aw
+        Aw(cont,0) = res_weight*A(cont,0);
+        Aw(cont,1) = res_weight*A(cont,1);
+        Aw(cont,2) = res_weight*A(cont,2);
+        Bw(cont)   = res_weight*B(cont);
+        cont++;
+      }
+
+    //Solve the linear system of equations using a minimum least squares method
+    AtA = Aw.transpose()*Aw;
+    AtB = Aw.transpose()*Bw;
+    Var = AtA.ldlt().solve(AtB);
+    res = A*Var - B;
+
+    ////Compute the energy
+    //energy = 0.f;
+    //for (unsigned int j=0; j<res.rows(); j++)
+    //	energy += log(1.f + mrpt::math::square(k*res(j)));
+    //printf("\nEnergy(%d) = %f", i, energy);
+  }
+
+  cov_odo = (1.f/float(num_valid_range-3))*AtA.inverse()*res.squaredNorm();
+  kai_loc_level_ = Var;
+
+  ROS_INFO_STREAM_COND(verbose, "[rf2o] COV_ODO:\n" << cov_odo);
 }
 
 void CLaserOdometry2D::Reset(const Pose3d& ini_pose/*, CObservation2DRangeScan scan*/)
 {
-	//Set the initial pose
+  //Set the initial pose
   laser_pose_ = ini_pose;
   laser_oldpose_ = ini_pose;
 
-    //readLaser(scan);
-	createImagePyramid();
-    //readLaser(scan);
-	createImagePyramid();
+  //readLaser(scan);
+  createImagePyramid();
+  //readLaser(scan);
+  createImagePyramid();
 }
-
 
 void CLaserOdometry2D::performWarping()
 {
   Eigen::Matrix3f acu_trans;
 
-	acu_trans.setIdentity();
-	for (unsigned int i=1; i<=level; i++)
-		acu_trans = transformations[i-1]*acu_trans;
+  acu_trans.setIdentity();
+  for (unsigned int i=1; i<=level; i++)
+    acu_trans = transformations[i-1]*acu_trans;
 
   Eigen::MatrixXf wacu = Eigen::MatrixXf::Constant(1, cols_i, 0.f);
 
   range_warped[image_level].setConstant(1, cols_i, 0.f);
 
-	const float cols_lim = float(cols_i-1);
-	const float kdtita = cols_lim/fovh;
+  const float cols_lim = float(cols_i-1);
+  const float kdtita = cols_lim/fovh;
 
-	for (unsigned int j = 0; j<cols_i; j++)
-	{
-		if (range[image_level](j) > 0.f)
-		{
-			//Transform point to the warped reference frame
-			const float x_w = acu_trans(0,0)*xx[image_level](j) + acu_trans(0,1)*yy[image_level](j) + acu_trans(0,2);
-			const float y_w = acu_trans(1,0)*xx[image_level](j) + acu_trans(1,1)*yy[image_level](j) + acu_trans(1,2);
+  for (unsigned int j = 0; j<cols_i; j++)
+  {
+    if (range[image_level](j) > 0.f)
+    {
+      //Transform point to the warped reference frame
+      const float x_w = acu_trans(0,0)*xx[image_level](j) + acu_trans(0,1)*yy[image_level](j) + acu_trans(0,2);
+      const float y_w = acu_trans(1,0)*xx[image_level](j) + acu_trans(1,1)*yy[image_level](j) + acu_trans(1,2);
       const float tita_w = std::atan2(y_w, x_w);
       const float range_w = std::sqrt(x_w*x_w + y_w*y_w);
 
-			//Calculate warping
-			const float uwarp = kdtita*(tita_w + 0.5*fovh);
+      //Calculate warping
+      const float uwarp = kdtita*(tita_w + 0.5*fovh);
 
-			//The warped pixel (which is not integer in general) contributes to all the surrounding ones
-			if (( uwarp >= 0.f)&&( uwarp < cols_lim))
-			{
-				const int uwarp_l = uwarp;
-				const int uwarp_r = uwarp_l + 1;
-				const float delta_r = float(uwarp_r) - uwarp;
-				const float delta_l = uwarp - float(uwarp_l);
+      //The warped pixel (which is not integer in general) contributes to all the surrounding ones
+      if (( uwarp >= 0.f)&&( uwarp < cols_lim))
+      {
+        const int uwarp_l = uwarp;
+        const int uwarp_r = uwarp_l + 1;
+        const float delta_r = float(uwarp_r) - uwarp;
+        const float delta_l = uwarp - float(uwarp_l);
 
-				//Very close pixel
+        //Very close pixel
         if (std::abs(std::round(uwarp) - uwarp) < 0.05f)
-				{
-					range_warped[image_level](round(uwarp)) += range_w;
+        {
+          range_warped[image_level](round(uwarp)) += range_w;
           wacu(std::round(uwarp)) += 1.f;
-				}
-				else
-				{
+        }
+        else
+        {
           const float w_r = delta_l*delta_l;
-					range_warped[image_level](uwarp_r) += w_r*range_w;
-					wacu(uwarp_r) += w_r;
+          range_warped[image_level](uwarp_r) += w_r*range_w;
+          wacu(uwarp_r) += w_r;
 
           const float w_l = delta_r*delta_r;
-					range_warped[image_level](uwarp_l) += w_l*range_w;
-					wacu(uwarp_l) += w_l;
-				}
-			}
-		}
-	}
+          range_warped[image_level](uwarp_l) += w_l*range_w;
+          wacu(uwarp_l) += w_l;
+        }
+      }
+    }
+  }
 
-	//Scale the averaged range and compute coordinates
-	for (unsigned int u = 0; u<cols_i; u++)
-	{
-		if (wacu(u) > 0.f)
-		{
-			const float tita = -0.5f*fovh + float(u)/kdtita;
-			range_warped[image_level](u) /= wacu(u);
+  //Scale the averaged range and compute coordinates
+  for (unsigned int u = 0; u<cols_i; u++)
+  {
+    if (wacu(u) > 0.f)
+    {
+      const float tita = -0.5f*fovh + float(u)/kdtita;
+      range_warped[image_level](u) /= wacu(u);
       xx_warped[image_level](u) = range_warped[image_level](u)*std::cos(tita);
       yy_warped[image_level](u) = range_warped[image_level](u)*std::sin(tita);
-		}
-		else
-		{
-			range_warped[image_level](u) = 0.f;
-			xx_warped[image_level](u) = 0.f;
-			yy_warped[image_level](u) = 0.f;
-		}
-	}
+    }
+    else
+    {
+      range_warped[image_level](u) = 0.f;
+      xx_warped[image_level](u) = 0.f;
+      yy_warped[image_level](u) = 0.f;
+    }
+  }
 }
-
-
-
-
 
 void CLaserOdometry2D::filterLevelSolution()
 {
-	//		Calculate Eigenvalues and Eigenvectors
-	//----------------------------------------------------------
+  //		Calculate Eigenvalues and Eigenvectors
+  //----------------------------------------------------------
   Eigen::SelfAdjointEigenSolver<Eigen::MatrixXf> eigensolver(cov_odo);
   if (eigensolver.info() != Eigen::Success)
-	{
+  {
     ROS_INFO_COND(verbose, "[rf2o] ERROR: Eigensolver couldn't find a solution. Pose is not updated");
-		return;
-	}
+    return;
+  }
 
-	//First, we have to describe both the new linear and angular speeds in the "eigenvector" basis
-	//-------------------------------------------------------------------------------------------------
+  //First, we have to describe both the new linear and angular speeds in the "eigenvector" basis
+  //-------------------------------------------------------------------------------------------------
   Eigen::Matrix<float,3,3> Bii;
   Eigen::Matrix<float,3,1> kai_b;
-	Bii = eigensolver.eigenvectors();
+  Bii = eigensolver.eigenvectors();
 
   kai_b = Bii.colPivHouseholderQr().solve(kai_loc_level_);
 
-	//Second, we have to describe both the old linear and angular speeds in the "eigenvector" basis too
-	//-------------------------------------------------------------------------------------------------
+  //Second, we have to describe both the old linear and angular speeds in the "eigenvector" basis too
+  //-------------------------------------------------------------------------------------------------
   MatrixS31 kai_loc_sub;
 
-	//Important: we have to substract the solutions from previous levels
+  //Important: we have to substract the solutions from previous levels
   Eigen::Matrix3f acu_trans;
-	acu_trans.setIdentity();
-	for (unsigned int i=0; i<level; i++)
-		acu_trans = transformations[i]*acu_trans;
+  acu_trans.setIdentity();
+  for (unsigned int i=0; i<level; i++)
+    acu_trans = transformations[i]*acu_trans;
 
-	kai_loc_sub(0) = -fps*acu_trans(0,2);
-	kai_loc_sub(1) = -fps*acu_trans(1,2);
-	if (acu_trans(0,0) > 1.f)
-		kai_loc_sub(2) = 0.f;
-    else
-    {
-      kai_loc_sub(2) = -fps*std::acos(acu_trans(0,0))*rf2o::sign(acu_trans(1,0));
-    }
+  kai_loc_sub(0) = -fps*acu_trans(0,2);
+  kai_loc_sub(1) = -fps*acu_trans(1,2);
+  if (acu_trans(0,0) > 1.f)
+    kai_loc_sub(2) = 0.f;
+  else
+  {
+    kai_loc_sub(2) = -fps*std::acos(acu_trans(0,0))*rf2o::sign(acu_trans(1,0));
+  }
   kai_loc_sub += kai_loc_old_;
 
   Eigen::Matrix<float,3,1> kai_b_old;
-	kai_b_old = Bii.colPivHouseholderQr().solve(kai_loc_sub);
+  kai_b_old = Bii.colPivHouseholderQr().solve(kai_loc_sub);
 
-	//Filter speed
+  //Filter speed
   const float cf = 15e3f*std::exp(-float(int(level))),
-              df = 0.05f*std::exp(-float(int(level)));
+      df = 0.05f*std::exp(-float(int(level)));
 
   Eigen::Matrix<float,3,1> kai_b_fil;
-	for (unsigned int i=0; i<3; i++)
-	{
-			kai_b_fil(i,0) = (kai_b(i,0) + (cf*eigensolver.eigenvalues()(i,0) + df)*kai_b_old(i,0))/(1.f + cf*eigensolver.eigenvalues()(i,0) + df);
-			//kai_b_fil_f(i,0) = (1.f*kai_b(i,0) + 0.f*kai_b_old_f(i,0))/(1.0f + 0.f);
-	}
+  for (unsigned int i=0; i<3; i++)
+  {
+    kai_b_fil(i,0) = (kai_b(i,0) + (cf*eigensolver.eigenvalues()(i,0) + df)*kai_b_old(i,0))/(1.f + cf*eigensolver.eigenvalues()(i,0) + df);
+    //kai_b_fil_f(i,0) = (1.f*kai_b(i,0) + 0.f*kai_b_old_f(i,0))/(1.0f + 0.f);
+  }
 
-	//Transform filtered speed to local reference frame and compute transformation
+  //Transform filtered speed to local reference frame and compute transformation
   Eigen::Matrix<float,3,1> kai_loc_fil = Bii.inverse().colPivHouseholderQr().solve(kai_b_fil);
 
-	//transformation
-	const float incrx = kai_loc_fil(0)/fps;
-	const float incry = kai_loc_fil(1)/fps;
-	const float rot = kai_loc_fil(2)/fps;
+  //transformation
+  const float incrx = kai_loc_fil(0)/fps;
+  const float incry = kai_loc_fil(1)/fps;
+  const float rot = kai_loc_fil(2)/fps;
   transformations[level](0,0) = std::cos(rot);
   transformations[level](0,1) = -std::sin(rot);
   transformations[level](1,0) = std::sin(rot);
   transformations[level](1,1) = std::cos(rot);
-	transformations[level](0,2) = incrx;
-	transformations[level](1,2) = incry;
+  transformations[level](0,2) = incrx;
+  transformations[level](1,2) = incry;
 }
-
 
 void CLaserOdometry2D::PoseUpdate()
 {
-	//First, compute the overall transformation
-	//---------------------------------------------------
+  //First, compute the overall transformation
+  //---------------------------------------------------
   Eigen::Matrix3f acu_trans;
-	acu_trans.setIdentity();
-	for (unsigned int i=1; i<=ctf_levels; i++)
-		acu_trans = transformations[i-1]*acu_trans;
+  acu_trans.setIdentity();
+  for (unsigned int i=1; i<=ctf_levels; i++)
+    acu_trans = transformations[i-1]*acu_trans;
 
 
-	//				Compute kai_loc and kai_abs
-	//--------------------------------------------------------
+  //				Compute kai_loc and kai_abs
+  //--------------------------------------------------------
   kai_loc_(0) = fps*acu_trans(0,2);
   kai_loc_(1) = fps*acu_trans(1,2);
-	if (acu_trans(0,0) > 1.f)
+  if (acu_trans(0,0) > 1.f)
     kai_loc_(2) = 0.f;
-	else
-    {
-      kai_loc_(2) = fps*std::acos(acu_trans(0,0))*rf2o::sign(acu_trans(1,0));
-    }
+  else
+  {
+    kai_loc_(2) = fps*std::acos(acu_trans(0,0))*rf2o::sign(acu_trans(1,0));
+  }
   //cout << endl << "Arc cos (incr tita): " << kai_loc_(2);
 
   float phi = rf2o::getYaw(laser_pose_.rotation());
@@ -894,11 +881,11 @@ void CLaserOdometry2D::PoseUpdate()
   kai_abs_(2) = kai_loc_(2);
 
 
-	//						Update poses
-	//-------------------------------------------------------
+  //						Update poses
+  //-------------------------------------------------------
   laser_oldpose_ = laser_pose_;
 
-//  Eigen::Matrix3f aux_acu = acu_trans;
+  //  Eigen::Matrix3f aux_acu = acu_trans;
   Pose3d pose_aux_2D = Pose3d::Identity();
 
   pose_aux_2D = rf2o::matrixYaw(double(kai_loc_(2)/fps));
@@ -909,48 +896,48 @@ void CLaserOdometry2D::PoseUpdate()
 
   last_increment_ = pose_aux_2D;
 
-	//				Compute kai_loc_old
-	//-------------------------------------------------------
+  //				Compute kai_loc_old
+  //-------------------------------------------------------
   phi = rf2o::getYaw(laser_pose_.rotation());
   kai_loc_old_(0) =  kai_abs_(0)*std::cos(phi) + kai_abs_(1)*std::sin(phi);
   kai_loc_old_(1) = -kai_abs_(0)*std::sin(phi) + kai_abs_(1)*std::cos(phi);
   kai_loc_old_(2) =  kai_abs_(2);
 
-    ROS_INFO_COND(verbose, "[rf2o] LASERodom = [%f %f %f]",
-                  laser_pose_.translation()(0),
-                  laser_pose_.translation()(1),
-                  rf2o::getYaw(laser_pose_.rotation()));
+  ROS_INFO_COND(verbose, "[rf2o] LASERodom = [%f %f %f]",
+                laser_pose_.translation()(0),
+                laser_pose_.translation()(1),
+                rf2o::getYaw(laser_pose_.rotation()));
 
-    //Compose Transformations
-    robot_pose_ = laser_pose_ * laser_pose_on_robot_inv_;
+  //Compose Transformations
+  robot_pose_ = laser_pose_ * laser_pose_on_robot_inv_;
 
-    ROS_INFO_COND(verbose, "BASEodom = [%f %f %f]",
-                  robot_pose_.translation()(0),
-                  robot_pose_.translation()(1),
-                  rf2o::getYaw(robot_pose_.rotation()));
+  ROS_INFO_COND(verbose, "BASEodom = [%f %f %f]",
+                robot_pose_.translation()(0),
+                robot_pose_.translation()(1),
+                rf2o::getYaw(robot_pose_.rotation()));
 
-    // Estimate linear/angular speeds (mandatory for base_local_planner)
-    // last_scan -> the last scan received
-    // last_odom_time -> The time of the previous scan lasser used to estimate the pose
-    //-------------------------------------------------------------------------------------
-    double time_inc_sec = (current_scan_time - last_odom_time).toSec();
-    last_odom_time = current_scan_time;
-    lin_speed = acu_trans(0,2) / time_inc_sec;
-    //double lin_speed = sqrt( mrpt::math::square(robot_oldpose.x()-robot_pose.x()) + mrpt::math::square(robot_oldpose.y()-robot_pose.y()) )/time_inc_sec;
+  // Estimate linear/angular speeds (mandatory for base_local_planner)
+  // last_scan -> the last scan received
+  // last_odom_time -> The time of the previous scan lasser used to estimate the pose
+  //-------------------------------------------------------------------------------------
+  double time_inc_sec = (current_scan_time - last_odom_time).toSec();
+  last_odom_time = current_scan_time;
+  lin_speed = acu_trans(0,2) / time_inc_sec;
+  //double lin_speed = sqrt( mrpt::math::square(robot_oldpose.x()-robot_pose.x()) + mrpt::math::square(robot_oldpose.y()-robot_pose.y()) )/time_inc_sec;
 
-    double ang_inc = rf2o::getYaw(robot_pose_.rotation()) -
-                     rf2o::getYaw(robot_oldpose_.rotation());
+  double ang_inc = rf2o::getYaw(robot_pose_.rotation()) -
+      rf2o::getYaw(robot_oldpose_.rotation());
 
-    if (ang_inc > 3.14159)
-        ang_inc -= 2*3.14159;
-    if (ang_inc < -3.14159)
-        ang_inc += 2*3.14159;
+  if (ang_inc > 3.14159)
+    ang_inc -= 2*3.14159;
+  if (ang_inc < -3.14159)
+    ang_inc += 2*3.14159;
 
-    ang_speed = ang_inc/time_inc_sec;
-    robot_oldpose_ = robot_pose_;
+  ang_speed = ang_inc/time_inc_sec;
+  robot_oldpose_ = robot_pose_;
 
-    //filter speeds
-    /*
+  //filter speeds
+  /*
     last_m_lin_speeds.push_back(lin_speed);
     if (last_m_lin_speeds.size()>4)
         last_m_lin_speeds.erase(last_m_lin_speeds.begin());

--- a/src/CLaserOdometry2DNode.cpp
+++ b/src/CLaserOdometry2DNode.cpp
@@ -20,6 +20,8 @@
 #include <tf/transform_broadcaster.h>
 #include <tf/transform_listener.h>
 
+namespace rf2o {
+
 class CLaserOdometry2DNode : CLaserOdometry2D
 {
 public:
@@ -249,6 +251,8 @@ void CLaserOdometry2DNode::publish()
   odom_pub.publish(odom);
 }
 
+} /* namespace rf2o */
+
 //-----------------------------------------------------------------------------------
 //                                   MAIN
 //-----------------------------------------------------------------------------------
@@ -256,7 +260,7 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "RF2O_LaserOdom");
 
-  CLaserOdometry2DNode myLaserOdomNode;
+  rf2o::CLaserOdometry2DNode myLaserOdomNode;
 
   ros::TimerOptions timer_opt;
   timer_opt.oneshot   = false;
@@ -264,7 +268,7 @@ int main(int argc, char** argv)
   timer_opt.callback_queue = ros::getGlobalCallbackQueue();
   timer_opt.tracked_object = ros::VoidConstPtr();
 
-  timer_opt.callback = boost::bind(&CLaserOdometry2DNode::process, &myLaserOdomNode, _1);
+  timer_opt.callback = boost::bind(&rf2o::CLaserOdometry2DNode::process, &myLaserOdomNode, _1);
   timer_opt.period   = ros::Rate(myLaserOdomNode.freq).expectedCycleTime();
 
   ros::Timer rf2o_timer = ros::NodeHandle("~").createTimer(timer_opt);

--- a/src/CLaserOdometry2DNode.cpp
+++ b/src/CLaserOdometry2DNode.cpp
@@ -11,6 +11,8 @@
 *
 * Maintainer: Javier G. Monroy
 * MAPIR group: http://mapir.isa.uma.es/
+*
+* Modifications: Jeremie Deray
 ******************************************************************************************** */
 
 #include "rf2o_laser_odometry/CLaserOdometry2D.h"
@@ -63,48 +65,48 @@ public:
 CLaserOdometry2DNode::CLaserOdometry2DNode() :
   CLaserOdometry2D()
 {
-    ROS_INFO("Initializing RF2O node...");
+  ROS_INFO("Initializing RF2O node...");
 
-    //Read Parameters
-    //----------------
-    ros::NodeHandle pn("~");
-    pn.param<std::string>("laser_scan_topic",laser_scan_topic,"/laser_scan");
-    pn.param<std::string>("odom_topic", odom_topic, "/odom_rf2o");
-    pn.param<std::string>("base_frame_id", base_frame_id, "/base_link");
-    pn.param<std::string>("odom_frame_id", odom_frame_id, "/odom");
-    pn.param<bool>("publish_tf", publish_tf, true);
-    pn.param<std::string>("init_pose_from_topic", init_pose_from_topic, "/base_pose_ground_truth");
-    pn.param<double>("freq",freq,10.0);
-    pn.param<bool>("verbose", verbose, true);
+  //Read Parameters
+  //----------------
+  ros::NodeHandle pn("~");
+  pn.param<std::string>("laser_scan_topic",laser_scan_topic,"/laser_scan");
+  pn.param<std::string>("odom_topic", odom_topic, "/odom_rf2o");
+  pn.param<std::string>("base_frame_id", base_frame_id, "/base_link");
+  pn.param<std::string>("odom_frame_id", odom_frame_id, "/odom");
+  pn.param<bool>("publish_tf", publish_tf, true);
+  pn.param<std::string>("init_pose_from_topic", init_pose_from_topic, "/base_pose_ground_truth");
+  pn.param<double>("freq",freq,10.0);
+  pn.param<bool>("verbose", verbose, true);
 
-    //Publishers and Subscribers
-    //--------------------------
-    odom_pub  = pn.advertise<nav_msgs::Odometry>(odom_topic, 5);
-    laser_sub = n.subscribe<sensor_msgs::LaserScan>(laser_scan_topic,1,&CLaserOdometry2DNode::LaserCallBack,this);
+  //Publishers and Subscribers
+  //--------------------------
+  odom_pub  = pn.advertise<nav_msgs::Odometry>(odom_topic, 5);
+  laser_sub = n.subscribe<sensor_msgs::LaserScan>(laser_scan_topic,1,&CLaserOdometry2DNode::LaserCallBack,this);
 
-    //init pose??
-    if (init_pose_from_topic != "")
-    {
-        initPose_sub = n.subscribe<nav_msgs::Odometry>(init_pose_from_topic,1,&CLaserOdometry2DNode::initPoseCallBack,this);
-        GT_pose_initialized  = false;
-    }
-    else
-    {
-        GT_pose_initialized = true;
-        initial_robot_pose.pose.pose.position.x = 0;
-        initial_robot_pose.pose.pose.position.y = 0;
-        initial_robot_pose.pose.pose.position.z = 0;
-        initial_robot_pose.pose.pose.orientation.w = 0;
-        initial_robot_pose.pose.pose.orientation.x = 0;
-        initial_robot_pose.pose.pose.orientation.y = 0;
-        initial_robot_pose.pose.pose.orientation.z = 0;
-    }
+  //init pose??
+  if (init_pose_from_topic != "")
+  {
+    initPose_sub = n.subscribe<nav_msgs::Odometry>(init_pose_from_topic,1,&CLaserOdometry2DNode::initPoseCallBack,this);
+    GT_pose_initialized  = false;
+  }
+  else
+  {
+    GT_pose_initialized = true;
+    initial_robot_pose.pose.pose.position.x = 0;
+    initial_robot_pose.pose.pose.position.y = 0;
+    initial_robot_pose.pose.pose.position.z = 0;
+    initial_robot_pose.pose.pose.orientation.w = 0;
+    initial_robot_pose.pose.pose.orientation.x = 0;
+    initial_robot_pose.pose.pose.orientation.y = 0;
+    initial_robot_pose.pose.pose.orientation.z = 0;
+  }
 
-    setLaserPoseFromTf();
+  setLaserPoseFromTf();
 
-    //Init variables
-    module_initialized = false;
-    first_laser_scan   = true;
+  //Init variables
+  module_initialized = false;
+  first_laser_scan   = true;
 
   ROS_INFO_STREAM("Listening laser scan from topic: " << laser_sub.getTopic());
 }
@@ -119,14 +121,14 @@ bool CLaserOdometry2DNode::setLaserPoseFromTf()
   transform.setIdentity();
   try
   {
-      tf_listener.lookupTransform(base_frame_id, last_scan.header.frame_id, ros::Time(0), transform);
-      retrieved = true;
+    tf_listener.lookupTransform(base_frame_id, last_scan.header.frame_id, ros::Time(0), transform);
+    retrieved = true;
   }
   catch (tf::TransformException &ex)
   {
-      ROS_ERROR("%s",ex.what());
-      ros::Duration(1.0).sleep();
-      retrieved = false;
+    ROS_ERROR("%s",ex.what());
+    ros::Duration(1.0).sleep();
+    retrieved = false;
   }
 
   //TF:transform -> Eigen::Isometry3d
@@ -135,8 +137,8 @@ bool CLaserOdometry2DNode::setLaserPoseFromTf()
   Eigen::Matrix3d R;
 
   for(int r = 0; r < 3; r++)
-      for(int c = 0; c < 3; c++)
-          R(r,c) = basis[r][c];
+    for(int c = 0; c < 3; c++)
+      R(r,c) = basis[r][c];
 
   Pose3d laser_tf(R);
 
@@ -152,21 +154,21 @@ bool CLaserOdometry2DNode::setLaserPoseFromTf()
 
 bool CLaserOdometry2DNode::scan_available()
 {
-    return new_scan_available;
+  return new_scan_available;
 }
 
 void CLaserOdometry2DNode::process(const ros::TimerEvent&)
 {
   if( is_initialized() && scan_available() )
   {
-      //Process odometry estimation
-      odometryCalculation(last_scan);
-      publish();
-      new_scan_available = false; //avoids the possibility to run twice on the same laser scan
+    //Process odometry estimation
+    odometryCalculation(last_scan);
+    publish();
+    new_scan_available = false; //avoids the possibility to run twice on the same laser scan
   }
   else
   {
-      ROS_WARN("Waiting for laser_scans....") ;
+    ROS_WARN("Waiting for laser_scans....") ;
   }
 }
 
@@ -176,36 +178,36 @@ void CLaserOdometry2DNode::process(const ros::TimerEvent&)
 
 void CLaserOdometry2DNode::LaserCallBack(const sensor_msgs::LaserScan::ConstPtr& new_scan)
 {
-    if (GT_pose_initialized)
-    {
-        //Keep in memory the last received laser_scan
-        last_scan = *new_scan;
-        current_scan_time = last_scan.header.stamp;
+  if (GT_pose_initialized)
+  {
+    //Keep in memory the last received laser_scan
+    last_scan = *new_scan;
+    current_scan_time = last_scan.header.stamp;
 
-        //Initialize module on first scan
-        if (!first_laser_scan)
-        {
-            //copy laser scan to internal variable
-            for (unsigned int i = 0; i<width; i++)
-                range_wf(i) = new_scan->ranges[i];
-            new_scan_available = true;
-        }
-        else
-        {
-          init(last_scan, initial_robot_pose.pose.pose);
-          first_laser_scan = false;
-        }
+    //Initialize module on first scan
+    if (!first_laser_scan)
+    {
+      //copy laser scan to internal variable
+      for (unsigned int i = 0; i<width; i++)
+        range_wf(i) = new_scan->ranges[i];
+      new_scan_available = true;
     }
+    else
+    {
+      init(last_scan, initial_robot_pose.pose.pose);
+      first_laser_scan = false;
+    }
+  }
 }
 
 void CLaserOdometry2DNode::initPoseCallBack(const nav_msgs::Odometry::ConstPtr& new_initPose)
 {
-    //Initialize module on first GT pose. Else do Nothing!
-    if (!GT_pose_initialized)
-    {
-        initial_robot_pose = *new_initPose;
-        GT_pose_initialized = true;
-    }
+  //Initialize module on first GT pose. Else do Nothing!
+  if (!GT_pose_initialized)
+  {
+    initial_robot_pose = *new_initPose;
+    GT_pose_initialized = true;
+  }
 }
 
 void CLaserOdometry2DNode::publish()
@@ -214,17 +216,17 @@ void CLaserOdometry2DNode::publish()
   //---------------------------------------
   if (publish_tf)
   {
-      //ROS_INFO("[rf2o] Publishing TF: [base_link] to [odom]");
-      geometry_msgs::TransformStamped odom_trans;
-      odom_trans.header.stamp = ros::Time::now();
-      odom_trans.header.frame_id = odom_frame_id;
-      odom_trans.child_frame_id = base_frame_id;
-      odom_trans.transform.translation.x = robot_pose_.translation()(0);
-      odom_trans.transform.translation.y = robot_pose_.translation()(1);
-      odom_trans.transform.translation.z = 0.0;
-      odom_trans.transform.rotation = tf::createQuaternionMsgFromYaw(rf2o::getYaw(robot_pose_.rotation()));
-      //send the transform
-      odom_broadcaster.sendTransform(odom_trans);
+    //ROS_INFO("[rf2o] Publishing TF: [base_link] to [odom]");
+    geometry_msgs::TransformStamped odom_trans;
+    odom_trans.header.stamp = ros::Time::now();
+    odom_trans.header.frame_id = odom_frame_id;
+    odom_trans.child_frame_id = base_frame_id;
+    odom_trans.transform.translation.x = robot_pose_.translation()(0);
+    odom_trans.transform.translation.y = robot_pose_.translation()(1);
+    odom_trans.transform.translation.z = 0.0;
+    odom_trans.transform.rotation = tf::createQuaternionMsgFromYaw(rf2o::getYaw(robot_pose_.rotation()));
+    //send the transform
+    odom_broadcaster.sendTransform(odom_trans);
   }
 
   //next, we'll publish the odometry message over ROS
@@ -252,22 +254,22 @@ void CLaserOdometry2DNode::publish()
 //-----------------------------------------------------------------------------------
 int main(int argc, char** argv)
 {
-    ros::init(argc, argv, "RF2O_LaserOdom");
+  ros::init(argc, argv, "RF2O_LaserOdom");
 
-    CLaserOdometry2DNode myLaserOdomNode;
+  CLaserOdometry2DNode myLaserOdomNode;
 
-    ros::TimerOptions timer_opt;
-    timer_opt.oneshot   = false;
-    timer_opt.autostart = true;
-    timer_opt.callback_queue = ros::getGlobalCallbackQueue();
-    timer_opt.tracked_object = ros::VoidConstPtr();
+  ros::TimerOptions timer_opt;
+  timer_opt.oneshot   = false;
+  timer_opt.autostart = true;
+  timer_opt.callback_queue = ros::getGlobalCallbackQueue();
+  timer_opt.tracked_object = ros::VoidConstPtr();
 
-    timer_opt.callback = boost::bind(&CLaserOdometry2DNode::process, &myLaserOdomNode, _1);
-    timer_opt.period   = ros::Rate(myLaserOdomNode.freq).expectedCycleTime();
+  timer_opt.callback = boost::bind(&CLaserOdometry2DNode::process, &myLaserOdomNode, _1);
+  timer_opt.period   = ros::Rate(myLaserOdomNode.freq).expectedCycleTime();
 
-    ros::Timer rf2o_timer = ros::NodeHandle("~").createTimer(timer_opt);
+  ros::Timer rf2o_timer = ros::NodeHandle("~").createTimer(timer_opt);
 
-    ros::spin();
+  ros::spin();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Mainly remove the dependency on the MRPT library using plain Eigen types instead.

**This PR comes on top of** #6.
Fixes #9.

Summary:
- remove dependency on MRPT
- add a `rf2o` namespace
- normalize the indentation chaos

**Note**: 
There is a remaining initialization issue.
I can't say if those changes brought it or else if it exists in the original code. Some value aren't properly initialized thus NaNs or crazy values are carried on throughout the execution.
After a couple hours tracking the uninitialized values issue with Valgrind, I gave up having found a fix.
A 'cheap' but nonetheless working fix takes place [here](https://github.com/MAPIRlab/rf2o_laser_odometry/commit/02421bac19bc99c2ba6c536c7f74a1320a5060fa#diff-228e5c0c563bd36be3d4e76229deaa0dR237) with notes for further debugging.
Valgrind runs this code happily and as far as I can tell from my experiments here the odometry works fine.