### PR TITLE
fix : Resolve rosdep install error and migrate to the latest ROS 2 format

### DIFF
--- a/include/rf2o_laser_odometry/CLaserOdometry2DNode.hpp
+++ b/include/rf2o_laser_odometry/CLaserOdometry2DNode.hpp
@@ -45,5 +45,11 @@ public:
   // CallBacks
   void LaserCallBack(const sensor_msgs::msg::LaserScan::SharedPtr new_scan);
   void initPoseCallBack(const nav_msgs::msg::Odometry::SharedPtr new_initPose);
+
+private:
+  rclcpp::Time node_start_time;         // 노드 시작 시간
+  rclcpp::Time last_warning_time;       // 마지막 경고 출력 시간
+  rclcpp::Time last_tf_error_time;      // 마지막 TF 에러 출력 시간
+  rclcpp::Time last_scan_received_time; // 마지막 스캔 수신 시간
 };
 

--- a/package.xml
+++ b/package.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rf2o_laser_odometry</name>
   <version>0.1.0</version>
-  <description>
-    Estimation of 2D odometry based on planar laser scans. Useful for mobile robots with innacurate base odometry.
-    For full description of the algorithm, please refer to:
-    Planar Odometry from a Radial Laser Scanner. A Range Flow-based Approach. ICRA 2016
-    Available at: http://mapir.isa.uma.es/mapirwebsite/index.php/mapir-downloads/papers/217
-  </description>
+  <description> Estimation of 2D odometry based on planar laser scans. Useful for mobile robots with
+    innacurate base odometry. For full description of the algorithm, please refer to: Planar
+    Odometry from a Radial Laser Scanner. A Range Flow-based Approach. ICRA 2016 Available at:
+    http://mapir.isa.uma.es/mapirwebsite/index.php/mapir-downloads/papers/217 </description>
 
   <maintainer email="jgmonroy@uma.es">Javier G. Monroy</maintainer>
+  <license>GPL v3</license>
   <author email="marianojt@uma.es"> Mariano Jaimez</author>
   <author email="jgmonroy@uma.es"> Javier G. Monroy</author>
-  <license>GPL v3</license> 
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
@@ -20,20 +19,18 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf2</build_depend>
-  <build_depend>tf2_ros</build_depend>  
+  <build_depend>tf2_ros</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>cmake_modules</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>rclcpp</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>tf2</run_depend>
-  <run_depend>tf2_ros</run_depend>  
-  <run_depend>eigen</run_depend>
-  <run_depend>cmake_modules</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>tf2_geometry_msgs</run_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf2</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>eigen</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/CLaserOdometry2DNode.cpp
+++ b/src/CLaserOdometry2DNode.cpp
@@ -23,6 +23,12 @@ CLaserOdometry2DNode::CLaserOdometry2DNode(): Node("CLaserOdometry2DNode")
 {
   RCLCPP_INFO(get_logger(), "Initializing RF2O node...");
 
+  // 시작 시간 및 경고 시간 초기화
+  node_start_time = this->now();
+  last_warning_time = node_start_time;
+  last_tf_error_time = node_start_time;
+  last_scan_received_time = node_start_time;
+
   // Read Parameters
   //----------------
   this->declare_parameter<std::string>("laser_scan_topic", "/scan");
@@ -86,6 +92,9 @@ void CLaserOdometry2DNode::LaserCallBack(const sensor_msgs::msg::LaserScan::Shar
     // Keep in memory the last received laser_scan
     last_scan = *new_scan;
     rf2o_ref.current_scan_time = last_scan.header.stamp;
+
+    // 스캔 수신 시간 갱신
+    last_scan_received_time = this->now();
     
     if (rf2o_ref.first_laser_scan == false)
     {
@@ -122,9 +131,17 @@ bool CLaserOdometry2DNode::setLaserPoseFromTf()
   }
   catch (tf2::TransformException &ex)
   {
-    RCLCPP_ERROR(get_logger(), "%s",ex.what());
+    // 5초마다 1번만 에러 출력
+    rclcpp::Duration since_last_error = this->now() - last_tf_error_time;
+    if (since_last_error.seconds() > 5.0)
+    {
+      RCLCPP_ERROR(get_logger(), "%s", ex.what());
+      last_tf_error_time = this->now();
+    }
     retrieved = false;
   }
+
+  if (!retrieved) return false;
 
   // Keep this transform as Eigen Matrix3d
   tf2::Transform transform;
@@ -176,7 +193,15 @@ void CLaserOdometry2DNode::process()
   else
   {
     // This is a warning. We depend on laser scans, so no meaning running faster than scan freq.
-    RCLCPP_WARN(get_logger(), "Waiting for laser_scans....");
+    // 5초 이상 스캔 수신이 없을 때만 경고 출력
+    rclcpp::Duration since_last_scan = this->now() - last_scan_received_time;
+    rclcpp::Duration since_last_warning = this->now() - last_warning_time;
+
+    if (since_last_scan.seconds() > 5.0 && since_last_warning.seconds() > 5.0)
+    {
+      RCLCPP_WARN(get_logger(), "Waiting for laser_scans....");
+      last_warning_time = this->now();
+    }
   }
 }
 


### PR DESCRIPTION
This PR updates the package.xml file to resolve dependency installation issues caused by outdated(for ROS1) package cmake_modules. The file has been migrated to comply with the latest ROS 2 package format.

- before fix
  ``` bash
  max@maxbuntu:~/ros2_ws$ rosdep install --from-paths src --ignore-src -y
  ERROR: the following packages/stacks could not have their rosdep keys resolved
  to system dependencies:
  rf2o_laser_odometry: Cannot locate rosdep definition for [cmake_modules]
  ```

- after fix
  ``` bash
  max@maxbuntu:~/ros2_ws$ rosdep install --from-paths src --ignore-src -y
  executing command [sudo -H apt-get install -y ros-jazzy-joint-state-publisher]
  Reading package lists... Done
  Building dependency tree... Done
  Reading state information... Done
  The following NEW packages will be installed:
    ros-jazzy-joint-state-publisher
  0 upgraded, 1 newly installed, 0 to remove and 159 not upgraded.
  Need to get 18.1 kB of archives.
  After this operation, 76.8 kB of additional disk space will be used.
  Get:1 http://packages.ros.org/ros2/ubuntu noble/main arm64 ros-jazzy-joint-state-publisher arm64 2.4.0-3noble.20250430.114522 [18.1 kB]
  Fetched 18.1 kB in 0s (1,465 kB/s)                         
  Selecting previously unselected package ros-jazzy-joint-state-publisher.
  (Reading database ... 312775 files and directories currently installed.)
  Preparing to unpack .../ros-jazzy-joint-state-publisher_2.4.0-3noble.20250430.114522_arm64.deb ...
  Unpacking ros-jazzy-joint-state-publisher (2.4.0-3noble.20250430.114522) ...
  Setting up ros-jazzy-joint-state-publisher (2.4.0-3noble.20250430.114522) ...
  #All required rosdeps installed successfully
  ```